### PR TITLE
Alterei a configuração de cores  das referências  cruzadas.

### DIFF
--- a/ufbathesis.cls
+++ b/ufbathesis.cls
@@ -102,7 +102,11 @@
 \if\@scr1
   \RequirePackage[dvips]{graphicx}
   \RequirePackage[dvips,usenames]{color}
-  \RequirePackage[colorlinks,backref]{hyperref}
+  \RequirePackage{hyperref}
+  \hypersetup{colorlinks=true,
+            linkcolor=black,
+            urlcolor=black,
+            citecolor=black}
 \fi
 \RequirePackage[alf]{abntex2cite}
 \RequirePackage{lastpage}


### PR DESCRIPTION
Ao utilizar o hyperef só com a opção [colorlinks],  ele utiliza a cor padrão. Configurei as cores para preto.

Signed-off-by: Alcemir R. Santos <alcemir.santos@gmail.com>